### PR TITLE
feat: 实现用户周报统计接口

### DIFF
--- a/biz/adaptor/controller/core_api/manage_api.go
+++ b/biz/adaptor/controller/core_api/manage_api.go
@@ -86,3 +86,18 @@ func UserStatistic(ctx context.Context, c *app.RequestContext) {
 	resp, err := manageapp.ManageSVC.UserStatistics(ctx, &req)
 	adaptor.PostProcess(ctx, c, &req, resp, err)
 }
+
+// GetWeeklyStats .
+// @router /admin/statistic/weekly [POST]
+func GetWeeklyStats(ctx context.Context, c *app.RequestContext) {
+	var err error
+	var req manage.GetWeeklyStatsReq
+	err = c.BindAndValidate(&req)
+	if err != nil {
+		c.String(consts.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := manageapp.ManageSVC.GetWeeklyStats(ctx, &req)
+	adaptor.PostProcess(ctx, c, &req, resp, err)
+}

--- a/biz/adaptor/router/core_api/core_api.go
+++ b/biz/adaptor/router/core_api/core_api.go
@@ -32,6 +32,7 @@ func Register(r *server.Hertz) {
 		{
 			_statistic := _admin.Group("/statistic", _statisticMw()...)
 			_statistic.POST("/user", append(_userstatisticMw(), core_api.UserStatistic)...)
+			_statistic.POST("/weekly", append(_getweeklystatsMw(), core_api.GetWeeklyStats)...)
 		}
 	}
 	{

--- a/biz/adaptor/router/core_api/middleware.go
+++ b/biz/adaptor/router/core_api/middleware.go
@@ -221,6 +221,11 @@ func _userstatisticMw() []app.HandlerFunc {
 	return nil
 }
 
+func _getweeklystatsMw() []app.HandlerFunc {
+	// your code...
+	return nil
+}
+
 func _getconversationextMw() []app.HandlerFunc {
 	// your code...
 	return nil

--- a/biz/application/dto/manage/manage.pb.go
+++ b/biz/application/dto/manage/manage.pb.go
@@ -1350,3 +1350,19 @@ func file_core_api_manage_proto_init() {
 	file_core_api_manage_proto_goTypes = nil
 	file_core_api_manage_proto_depIdxs = nil
 }
+
+// GetWeeklyStatsReq is the request for GetWeeklyStats.
+type GetWeeklyStatsReq struct {
+}
+
+// GetWeeklyStatsResp is the response for GetWeeklyStats.
+type GetWeeklyStatsResp struct {
+	Resp             *basic.Response `protobuf:"bytes,1,opt,name=resp,proto3" json:"resp"`
+	TotalUsers       int64           `protobuf:"varint,2,opt,name=totalUsers,proto3" json:"totalUsers"`
+	NewUsersThisWeek int64           `protobuf:"varint,3,opt,name=newUsersThisWeek,proto3" json:"newUsersThisWeek"`
+	NewUsersLastWeek int64           `protobuf:"varint,4,opt,name=newUsersLastWeek,proto3" json:"newUsersLastWeek"`
+	WeeklyAvgDAU     int64           `protobuf:"varint,5,opt,name=weeklyAvgDAU,proto3" json:"weeklyAvgDAU"`
+	MonthlyAvgDAU    int64           `protobuf:"varint,6,opt,name=monthlyAvgDAU,proto3" json:"monthlyAvgDAU"`
+	WeekStart        string          `protobuf:"bytes,7,opt,name=weekStart,proto3" json:"weekStart"`
+	WeekEnd          string          `protobuf:"bytes,8,opt,name=weekEnd,proto3" json:"weekEnd"`
+}

--- a/biz/application/service/base/app.go
+++ b/biz/application/service/base/app.go
@@ -62,6 +62,6 @@ func InitService(deps *AppDependency) {
 	feedbackapp.InitFeedbackSVC(deps.MessageMapper, deps.FeedbackMapper, deps.His)
 	userapp.InitUserSVC(deps.UserMapper)
 	intelligence.InitIntelligenceSVC()
-	manageapp.InitManageSVC(deps.UserMapper, deps.FeedbackMapper)
+	manageapp.InitManageSVC(deps.UserMapper, deps.FeedbackMapper, deps.MessageMapper)
 	system.InitAttachSVC(deps.COS, deps.UserMapper)
 }

--- a/biz/application/service/manage/init.go
+++ b/biz/application/service/manage/init.go
@@ -2,12 +2,14 @@ package manage
 
 import (
 	"github.com/xh-polaris/innospark-core-api/biz/infra/mapper/feedback"
+	"github.com/xh-polaris/innospark-core-api/biz/infra/mapper/message"
 	"github.com/xh-polaris/innospark-core-api/biz/infra/mapper/user"
 )
 
-func InitManageSVC(user user.MongoMapper, feedback feedback.MongoMapper) {
+func InitManageSVC(user user.MongoMapper, feedback feedback.MongoMapper, message message.MongoMapper) {
 	ManageSVC = &ManageService{
 		UserMapper:     user,
 		FeedbackMapper: feedback,
+		MessageMapper:  message,
 	}
 }

--- a/biz/application/service/manage/manage.go
+++ b/biz/application/service/manage/manage.go
@@ -10,6 +10,7 @@ import (
 	"github.com/xh-polaris/innospark-core-api/biz/application/dto/manage"
 	"github.com/xh-polaris/innospark-core-api/biz/conf"
 	"github.com/xh-polaris/innospark-core-api/biz/infra/mapper/feedback"
+	"github.com/xh-polaris/innospark-core-api/biz/infra/mapper/message"
 	"github.com/xh-polaris/innospark-core-api/biz/infra/mapper/user"
 	"github.com/xh-polaris/innospark-core-api/biz/infra/util"
 	"github.com/xh-polaris/innospark-core-api/pkg/errorx"
@@ -21,6 +22,7 @@ var ManageSVC *ManageService
 type ManageService struct {
 	UserMapper     user.MongoMapper
 	FeedbackMapper feedback.MongoMapper
+	MessageMapper  message.MongoMapper
 }
 
 func (m *ManageService) AdminLogin(ctx context.Context, req *manage.AdminLoginReq) (resp *manage.AdminLoginResp, err error) {
@@ -215,4 +217,70 @@ func calcLinearRegression(acc []*manage.UserStatisticsResp_Item) *manage.UserSta
 		W: w,
 		B: b,
 	}
+}
+
+var shanghaiLoc = func() *time.Location {
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		return time.FixedZone("CST", 8*60*60)
+	}
+	return loc
+}()
+
+func (m *ManageService) GetWeeklyStats(ctx context.Context, req *manage.GetWeeklyStatsReq) (*manage.GetWeeklyStatsResp, error) {
+	if err := checkAdmin(ctx); err != nil {
+		return nil, err
+	}
+	thisTuesday, lastTuesday, twoAgoTuesday := calcWeekBounds(time.Now())
+	monthStart := calcMonthStart(time.Now())
+	tomorrow := truncDay(time.Now().In(shanghaiLoc)).Add(24 * time.Hour)
+
+	totalUsers, err := m.UserMapper.CountUserByCreateTime(ctx, time.Time{}, true)
+	if err != nil {
+		return nil, errorx.New(errno.ErrGetWeeklyStats)
+	}
+	newUsersThisWeek, err := m.UserMapper.CountUserByCreateTimeBetween(ctx, lastTuesday, thisTuesday)
+	if err != nil {
+		return nil, errorx.New(errno.ErrGetWeeklyStats)
+	}
+	newUsersLastWeek, err := m.UserMapper.CountUserByCreateTimeBetween(ctx, twoAgoTuesday, lastTuesday)
+	if err != nil {
+		return nil, errorx.New(errno.ErrGetWeeklyStats)
+	}
+	weeklyActiveUsers, err := m.MessageMapper.CountActiveUsers(ctx, lastTuesday, thisTuesday)
+	if err != nil {
+		return nil, errorx.New(errno.ErrGetWeeklyStats)
+	}
+	monthlyActiveUsers, err := m.MessageMapper.CountActiveUsers(ctx, monthStart, tomorrow)
+	if err != nil {
+		return nil, errorx.New(errno.ErrGetWeeklyStats)
+	}
+	return &manage.GetWeeklyStatsResp{
+		Resp:             util.Success(),
+		TotalUsers:       totalUsers,
+		NewUsersThisWeek: newUsersThisWeek,
+		NewUsersLastWeek: newUsersLastWeek,
+		WeeklyAvgDAU:     weeklyActiveUsers,
+		MonthlyAvgDAU:    monthlyActiveUsers,
+		WeekStart:        lastTuesday.Format(time.RFC3339),
+		WeekEnd:          thisTuesday.Format(time.RFC3339),
+	}, nil
+}
+
+func calcWeekBounds(now time.Time) (thisTuesday, lastTuesday, twoAgoTuesday time.Time) {
+	now = now.In(shanghaiLoc)
+	daysBack := (int(now.Weekday()) - 2 + 7) % 7
+	thisTuesday = truncDay(now.AddDate(0, 0, -daysBack))
+	lastTuesday = thisTuesday.AddDate(0, 0, -7)
+	twoAgoTuesday = lastTuesday.AddDate(0, 0, -7)
+	return
+}
+
+func calcMonthStart(now time.Time) time.Time {
+	now = now.In(shanghaiLoc)
+	return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, shanghaiLoc)
+}
+
+func truncDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
 }

--- a/biz/infra/mapper/message/mapper.go
+++ b/biz/infra/mapper/message/mapper.go
@@ -3,6 +3,7 @@ package message
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/xh-polaris/innospark-core-api/biz/application/dto/basic"
 	"github.com/xh-polaris/innospark-core-api/biz/conf"
@@ -30,6 +31,7 @@ type MongoMapper interface {
 	Feedback(ctx context.Context, mid primitive.ObjectID, feedback int32) (_ *Message, err error)
 	RetrieveMessages(ctx context.Context, conversation string, size int) (msgs []*Message, err error)
 	InsertOne(ctx context.Context, msg *Message) error
+	CountActiveUsers(ctx context.Context, start, end time.Time) (int64, error)
 }
 
 type mongoMapper struct {
@@ -123,4 +125,27 @@ func (m *mongoMapper) Feedback(ctx context.Context, mid primitive.ObjectID, feed
 		return nil, err
 	}
 	return &ori, err
+}
+
+// CountActiveUsers 统计 [start, end) 内发过消息（role=user）的去重用户数
+func (m *mongoMapper) CountActiveUsers(ctx context.Context, start, end time.Time) (int64, error) {
+	pipeline := bson.A{
+		bson.M{"$match": bson.M{
+			cst.CreateTime: bson.M{cst.GTE: start, cst.LT: end},
+			"role":         cst.UserEnum,
+		}},
+		bson.M{"$group": bson.M{"_id": "$" + cst.UserId}},
+		bson.M{"$count": "total"},
+	}
+	type countResult struct {
+		Total int64 `bson:"total"`
+	}
+	var res []countResult
+	if err := m.conn.Aggregate(ctx, &res, pipeline); err != nil {
+		return 0, err
+	}
+	if len(res) == 0 {
+		return 0, nil
+	}
+	return res[0].Total, nil
 }

--- a/biz/infra/mapper/user/mapper.go
+++ b/biz/infra/mapper/user/mapper.go
@@ -33,6 +33,7 @@ type MongoMapper interface {
 	UnForbidden(ctx context.Context, id string) error
 	ListUser(ctx context.Context, page *basic.Page, status, sortedBy, reverse int32) (int64, []*User, error)
 	CountUserByCreateTime(ctx context.Context, time time.Time, after bool) (int64, error)
+	CountUserByCreateTimeBetween(ctx context.Context, start, end time.Time) (int64, error)
 
 	UpdateField(ctx context.Context, uid primitive.ObjectID, update bson.M) error
 	existField(ctx context.Context, field string, value interface{}) (bool, error)
@@ -194,10 +195,14 @@ func (m *mongoMapper) ExistUsername(ctx context.Context, username string) (bool,
 func (m *mongoMapper) CountUserByCreateTime(ctx context.Context, t time.Time, after bool) (int64, error) {
 	var filter bson.M
 	if after {
-		filter = bson.M{cst.CreateTime: bson.M{cst.GTE: t}} // 统计 t 之后（含 t）
+		filter = bson.M{cst.CreateTime: bson.M{cst.GTE: t}}
 	} else {
-		filter = bson.M{cst.CreateTime: bson.M{cst.LT: t}} // 统计 t 之前
+		filter = bson.M{cst.CreateTime: bson.M{cst.LT: t}}
 	}
-	total, err := m.conn.CountDocuments(ctx, filter)
-	return total, err
+	return m.conn.CountDocuments(ctx, filter)
+}
+
+func (m *mongoMapper) CountUserByCreateTimeBetween(ctx context.Context, start, end time.Time) (int64, error) {
+	filter := bson.M{cst.CreateTime: bson.M{cst.GTE: start, cst.LT: end}}
+	return m.conn.CountDocuments(ctx, filter)
 }

--- a/types/errno/user.go
+++ b/types/errno/user.go
@@ -8,6 +8,7 @@ const (
 	ErrForbidden       = 100_000_003
 	ErrUpdateUserField = 100_000_004
 	ErrGetProfile      = 100_000_005
+	ErrGetWeeklyStats  = 100_000_006
 )
 
 func init() {
@@ -34,6 +35,11 @@ func init() {
 	code.Register(
 		ErrGetProfile,
 		"获取用户信息失败",
+		code.WithAffectStability(false),
+	)
+	code.Register(
+		ErrGetWeeklyStats,
+		"获取周报统计失败",
 		code.WithAffectStability(false),
 	)
 }


### PR DESCRIPTION
- 新增 GetWeeklyStats 接口，统计总用户数、周新增用户数、有对话用户数
- 用 message 集合按 role=2+create_time 统计有对话用户数，替代原 login_time 快照方案
- user mapper 新增 CountUserByCreateTimeBetween
- message mapper 新增 CountActiveUsers
- ManageService 注入 MessageMapper
- controller 补上 BindAndValidate